### PR TITLE
Fix: Restrict publishing to upstream repository only

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: read
+      packages: write
     env:
       DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
     steps:
@@ -61,7 +61,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Debug - Publishing start
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'guidewire-oss/fern-mycelium'
         run: |
           echo "🚀 Starting publish step..."
           echo "📦 Version: ${{ steps.vars.outputs.VERSION }}"
@@ -70,13 +70,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # required for authenticated API access
         uses: dagger/dagger-for-github@8.0.0
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'guidewire-oss/fern-mycelium'
         with:
           version: "0.18.9"
           call: publish --src . --version=${{ steps.vars.outputs.VERSION }} --github-token=env://GITHUB_TOKEN
 
       - name: Debug - Publish completed
-        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'guidewire-oss/fern-mycelium'
         run: echo "✅ Publish completed successfully"
 
   release:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -10,9 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
     env:
       DAGGER_CLOUD_TOKEN: ${{ secrets.DAGGER_CLOUD_TOKEN }}
+      # Only publish on upstream repository to prevent permission issues on forks
+      IS_UPSTREAM: ${{ github.repository == 'guidewire-oss/fern-mycelium' }}
+      IS_MAIN_OR_TAG: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -61,22 +63,26 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Debug - Publishing start
-        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'guidewire-oss/fern-mycelium'
+        if: env.IS_MAIN_OR_TAG == 'true' && env.IS_UPSTREAM == 'true'
         run: |
           echo "🚀 Starting publish step..."
           echo "📦 Version: ${{ steps.vars.outputs.VERSION }}"
 
       - name: Publish (optional, only on main)
+        # Grant packages:write permission only for this specific step
+        permissions:
+          contents: read
+          packages: write
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # required for authenticated API access
         uses: dagger/dagger-for-github@8.0.0
-        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'guidewire-oss/fern-mycelium'
+        if: env.IS_MAIN_OR_TAG == 'true' && env.IS_UPSTREAM == 'true'
         with:
           version: "0.18.9"
           call: publish --src . --version=${{ steps.vars.outputs.VERSION }} --github-token=env://GITHUB_TOKEN
 
       - name: Debug - Publish completed
-        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) && github.repository == 'guidewire-oss/fern-mycelium'
+        if: env.IS_MAIN_OR_TAG == 'true' && env.IS_UPSTREAM == 'true'
         run: echo "✅ Publish completed successfully"
 
   release:


### PR DESCRIPTION
- Add repository check to publish steps: github.repository == 'guidewire-oss/fern-mycelium'
- Prevents forks from attempting to publish to ghcr.io
- Publish steps now only run on upstream repository pushes/tags
- Maintains security by limiting container registry access
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Restricted publish steps in the pipeline to only run on the upstream repository, blocking forks from publishing to the container registry.

- **Security**
  - Added a repository check so only guidewire-oss/fern-mycelium can trigger publish actions.

<!-- End of auto-generated description by cubic. -->

